### PR TITLE
[FIX]: sincronizar disconnect/connect usando Promise en webSocket

### DIFF
--- a/src/contexts/authContext.tsx
+++ b/src/contexts/authContext.tsx
@@ -2,6 +2,7 @@
 
 import { DEBT_PATHS } from '@/constants/paths/debtPaths';
 import { PUBLIC_PATHS } from '@/constants/paths/publicPaths';
+import { disconnectWebSocket } from '@/lib/websocket';
 import { Driver } from '@/models/driver';
 import { User } from '@/models/user';
 import { LoginData } from '@/modules/auth/schemas/loginSchema';
@@ -280,6 +281,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     } catch (error) {
       console.error('Error during logout:', error);
     } finally {
+      disconnectWebSocket();
       setUser(null);
       setAccessToken(null);
       router.push('/login');

--- a/src/lib/websocket.ts
+++ b/src/lib/websocket.ts
@@ -5,31 +5,44 @@ let stompClient: Stomp.Client | null = null;
 
 export const connectWebSocket = (
   token: string,
-   onMessage: (payload: unknown) => void
-) => {  
-  const socket = new SockJS(
-    `${process.env.NEXT_PUBLIC_API_URL}/ws`
-  );
+  onMessage: (payload: unknown) => void
+): Promise<void> => {
+  return new Promise((resolve, reject) => {
+    const socket = new SockJS(
+      `${process.env.NEXT_PUBLIC_API_URL}/ws`
+    );
 
-  stompClient = Stomp.over(socket);
-  stompClient.debug = () => {};
+    stompClient = Stomp.over(socket);
+    stompClient.debug = () => {};
 
-  stompClient.connect(
-    { Authorization: `Bearer ${token}` },
-    () => {
-      stompClient?.subscribe('/user/queue/notification', (message) => {
-        const payload = JSON.parse(message.body);
-        onMessage(payload);
-      });
-    }
-  );
+    stompClient.connect(
+      { Authorization: `Bearer ${token}` },
+      () => {
+        stompClient?.subscribe('/user/queue/notification', (message) => {
+          const payload = JSON.parse(message.body);
+          onMessage(payload);
+        });
+
+        resolve(); 
+      },
+      (error) => {
+        console.error("WS connection error:", error);
+        reject(error);
+      }
+    );
+  });
 };
 
-// AGREGAR ESTA FUNCIÓN
-export const disconnectWebSocket = () => {
-  if (stompClient && stompClient.connected) {
-    stompClient.disconnect(() => {
-    });
-    stompClient = null;
-  }
+
+export const disconnectWebSocket = (): Promise<void> => {
+  return new Promise((resolve) => {
+    if (stompClient && stompClient.connected) {
+      stompClient.disconnect(() => {
+        stompClient = null;
+        resolve();
+      });
+    } else {
+      resolve();
+    }
+  });
 };

--- a/src/providers/WebSocketProvider.tsx
+++ b/src/providers/WebSocketProvider.tsx
@@ -46,22 +46,28 @@ export function WebSocketProvider({
   const { showNotification } = useNotification();
   const { user, accessToken } = useAuth(); // Token que viene del Login
 
-  const connect = useCallback((tokenToConnect: string) => {
+  const connect = useCallback(async (tokenToConnect: string) => {
     if (!tokenToConnect) return;
-    
-    disconnectWebSocket(); // limpiar el ws antes
 
-    connectWebSocket(tokenToConnect, (payload: unknown) => {
-      const wsPayload = payload as WebSocketPayload;
-      showNotification({
-        type: NotificationType.PAYMENT_PENDING,
-        title: wsPayload.pushTitle,
-        message: wsPayload.pushBody,
-        data: wsPayload.data,
+    try {
+      await disconnectWebSocket();
+
+      await connectWebSocket(tokenToConnect, (payload: unknown) => {
+        const wsPayload = payload as WebSocketPayload;
+
+        showNotification({
+          type: NotificationType.PAYMENT_PENDING,
+          title: wsPayload.pushTitle,
+          message: wsPayload.pushBody,
+          data: wsPayload.data,
+        });
       });
-    });
 
-    setIsConnected(true);
+      setIsConnected(true);
+    } catch (error) {
+      console.error("Error conectando WS:", error);
+      setIsConnected(false);
+    }
   }, [showNotification]);
 
   const reconnect = useCallback((newToken: string) => {
@@ -74,16 +80,16 @@ export function WebSocketProvider({
     // 2. Si no, usa el initialToken (f5).
     const effectiveToken = accessToken || initialToken;
 
-    if (user && effectiveToken && !isConnected) {
+    if (user && effectiveToken) {
       connect(effectiveToken);
     }
 
     // Si el usuario hace logout, desconectar el ws
-    if (!user && isConnected) {
+    if (!user) {
       disconnectWebSocket();
       setIsConnected(false);
     }
-  }, [user, accessToken, initialToken, isConnected, connect]);
+  }, [user, accessToken, initialToken, connect]);
 
   return (
     <WebSocketContext.Provider value={{ isConnected, reconnect }}>


### PR DESCRIPTION
- desconectar el web socket en el logout
- disconnectWebSocket ahora retorna una Promise y se espera con await
- soluciona sesiones WS duplicadas y mezcla de notificaciones